### PR TITLE
Perl lint: move version after strictures

### DIFF
--- a/src/lcg-infosites
+++ b/src/lcg-infosites
@@ -18,11 +18,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-my $version = '3.0.1';
-
 use Net::LDAP;
 use Net::LDAP::Entry;
 use strict;
+
+my $version = '3.0.1';
 
 $ENV{LANG} = $ENV{LC_ALL} = 'C';
 (my $prog = $0) =~ s-.*/--;


### PR DESCRIPTION
Address Perl lint reports, aiming at doing minimal changes.