### PR TITLE
GitHub actions: update actions that can be updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           make clean rpm
           rpmlint --file .rpmlint.ini build/RPMS/noarch/*.el7.noarch.rpm
       - name: Upload RPMs
+        # XXX: actions/upload-artifact > 3 does not work on centos7
         uses: actions/upload-artifact@v3
         with:
           name: rpms7
@@ -52,7 +53,7 @@ jobs:
           make clean rpm
           rpmlint --file .rpmlint.ini build/RPMS/noarch/*.el${{ matrix.almalinux-version }}.noarch.rpm
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpms${{ matrix.almalinux-version }}
           path: |
@@ -64,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/centos/centos:7
     steps:
+      # XXX: actions/download-artifact > 3 does not work on centos7
       - uses: actions/download-artifact@v3
         with:
           name: rpms7
@@ -77,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     container: almalinux:8
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rpms8
       - name: Install generated RPMs
@@ -90,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     container: almalinux:9
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rpms9
       - name: Install generated RPMs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           make clean rpm
       - name: Upload RPMs
+        # XXX: actions/upload-artifact > 3 does not work on centos7
         uses: actions/upload-artifact@v3
         with:
           name: rpms7
@@ -51,7 +52,7 @@ jobs:
         run: |
           make clean rpm
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpms8
           path: |
@@ -74,7 +75,7 @@ jobs:
         run: |
           make clean rpm
       - name: Upload RPMs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rpms9
           path: |
@@ -88,6 +89,7 @@ jobs:
     needs: centos7
     runs-on: ubuntu-latest
     steps:
+      # XXX: actions/download-artifact > 3 does not work on centos7
       - uses: actions/download-artifact@v3
         with:
           name: rpms7
@@ -115,7 +117,7 @@ jobs:
     needs: almalinux8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rpms8
       - name: Find package name
@@ -142,7 +144,7 @@ jobs:
     needs: almalinux9
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: rpms9
       - name: Find package name


### PR DESCRIPTION
GitHub actions: update actions that can be updated.
CentOS 7 do not support most recent version of [upload|download]-artifact and checkout.